### PR TITLE
Add admin tools page

### DIFF
--- a/components/pages/team/TeamNavbar.tsx
+++ b/components/pages/team/TeamNavbar.tsx
@@ -7,6 +7,7 @@ import {
 	faLink,
 	faTag,
 	faUserGroup,
+	faWrench,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
@@ -143,6 +144,12 @@ const TeamNavbar = ({ router }: Props) => {
 							label="Users"
 							href="/team/dashboard/users"
 							active={pathname === "/team/dashboard/users"}
+						/>
+						<NavItem
+							icon={faWrench}
+							label="Tools"
+							href="/team/r/tools"
+							active={pathname === "/team/r/tools"}
 						/>
 					</div>
 				)}

--- a/components/pages/team/tools/BulkAssetTool.tsx
+++ b/components/pages/team/tools/BulkAssetTool.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState } from "react";
+import { reqGetAssets, reqUpdateAsset } from "../../../../services/api/asset.service";
+import { Asset } from "../../../../types";
+import { AssetStatuses } from "../../../../models/assetStatus.model";
+import Spinner from "../../../general/Spinner";
+import toast from "react-hot-toast";
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+const BulkAssetTool = () => {
+	const [assets, setAssets] = useState<Asset[] | null>(null);
+	const [selected, setSelected] = useState<Set<number>>(new Set());
+	const [targetStatus, setTargetStatus] = useState<number | "">("");
+	const [applying, setApplying] = useState(false);
+	const [search, setSearch] = useState("");
+
+	const fetchAssets = useCallback(async () => {
+		setAssets(null);
+		setSelected(new Set());
+		const res = await reqGetAssets({
+			limit: 500,
+			offset: 0,
+			sort: "DESC",
+			...(search ? { search } : {}),
+		});
+		if (res.success) {
+			setAssets(res.data);
+		} else {
+			setAssets([]);
+			toast.error("Failed to load assets");
+		}
+	}, [search]);
+
+	useEffect(() => {
+		fetchAssets();
+	}, [fetchAssets]);
+
+	const toggleSelect = (id: number) => {
+		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	};
+
+	const toggleAll = () => {
+		if (!assets) return;
+		if (selected.size === assets.length) {
+			setSelected(new Set());
+		} else {
+			setSelected(new Set(assets.map((a) => a.id)));
+		}
+	};
+
+	const applyBulkStatus = async () => {
+		if (!targetStatus || selected.size === 0) return;
+		setApplying(true);
+		let succeeded = 0;
+		let failed = 0;
+
+		const ids = Array.from(selected);
+		for (let i = 0; i < ids.length; i += 5) {
+			const batch = ids.slice(i, i + 5);
+			const results = await Promise.all(
+				batch.map((id) => reqUpdateAsset(id, { status: targetStatus as number }))
+			);
+			results.forEach((r) => {
+				if (r.success) succeeded++;
+				else failed++;
+			});
+		}
+
+		setApplying(false);
+		if (failed === 0) {
+			toast.success(`Updated ${succeeded} asset${succeeded !== 1 ? "s" : ""}`, { position: "top-center" });
+		} else {
+			toast.error(`${succeeded} succeeded, ${failed} failed`, { position: "top-center" });
+		}
+		setSelected(new Set());
+		setTargetStatus("");
+		fetchAssets();
+	};
+
+	const statusLabel = (id: number) => AssetStatuses.find((s) => s.id === id)?.name ?? "Unknown";
+
+	const statusBadge = (shortName: string) => {
+		const map: Record<string, string> = {
+			in_service: "bg-emerald-50 text-emerald-700 border-emerald-200",
+			ready_for_sale: "bg-blue-50 text-blue-700 border-blue-200",
+			pending_repair: "bg-amber-50 text-amber-700 border-amber-200",
+			broken: "bg-red-50 text-red-600 border-red-200",
+			lost: "bg-slate-100 text-slate-600 border-slate-300",
+			warning: "bg-orange-50 text-orange-700 border-orange-200",
+		};
+		return map[shortName] ?? "bg-slate-50 text-slate-600 border-slate-200";
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			{/* Controls */}
+			<div className="flex flex-col sm:flex-row gap-3 items-start sm:items-end">
+				{/* Search */}
+				<div className="flex flex-col gap-1.5 flex-1 min-w-0">
+					<label className="text-xs font-semibold text-slate-600">Search</label>
+					<input
+						type="text"
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						placeholder="Search assets..."
+						className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-700 shadow-sm placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+					/>
+				</div>
+
+				{/* Divider */}
+				<div className="hidden sm:block h-9 w-px bg-slate-200" />
+
+				{/* Target status */}
+				<div className="flex flex-col gap-1.5">
+					<label className="text-xs font-semibold text-slate-600">Set Status To</label>
+					<select
+						value={targetStatus}
+						onChange={(e) => setTargetStatus(e.target.value ? Number(e.target.value) : "")}
+						className="h-9 rounded-lg border border-slate-200 bg-white px-3 pr-7 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400 appearance-none cursor-pointer"
+					>
+						<option value="">Select status...</option>
+						{AssetStatuses.map((s) => (
+							<option key={s.id} value={s.id}>{s.name}</option>
+						))}
+					</select>
+				</div>
+
+				{/* Apply button */}
+				<button
+					onClick={applyBulkStatus}
+					disabled={!targetStatus || selected.size === 0 || applying}
+					className="h-9 rounded-lg bg-blue-600 px-4 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+				>
+					{applying ? (
+						<>
+							<svg className="h-3.5 w-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+								<circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+								<path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+							</svg>
+							Applying...
+						</>
+					) : (
+						<>Apply to {selected.size} selected</>
+					)}
+				</button>
+			</div>
+
+			{/* Table */}
+			{assets === null ? (
+				<div className="flex items-center justify-center py-12">
+					<Spinner />
+				</div>
+			) : assets.length === 0 ? (
+				<div className="flex flex-col items-center justify-center py-12 text-center">
+					<p className="text-sm font-medium text-slate-700">No assets found</p>
+					<p className="mt-1 text-xs text-slate-400">Try adjusting your search</p>
+				</div>
+			) : (
+				<div className="overflow-hidden rounded-xl border border-slate-100">
+					{/* Header */}
+					<div className="grid grid-cols-[40px_1fr_120px_120px] items-center gap-x-3 border-b border-slate-100 bg-slate-50/80 px-4 py-2 text-xs font-semibold text-slate-500">
+						<div className="flex items-center justify-center">
+							<input
+								type="checkbox"
+								checked={assets.length > 0 && selected.size === assets.length}
+								onChange={toggleAll}
+								className="h-3.5 w-3.5 rounded border-slate-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+							/>
+						</div>
+						<p>Name</p>
+						<p className="hidden sm:block">Category</p>
+						<p className="hidden sm:block">Status</p>
+					</div>
+
+					{/* Rows */}
+					<div className="max-h-[400px] overflow-y-auto">
+						{assets.map((asset) => (
+							<div
+								key={asset.id}
+								onClick={() => toggleSelect(asset.id)}
+								className={`grid grid-cols-[40px_1fr_120px_120px] items-center gap-x-3 border-b border-slate-50 px-4 py-2.5 transition-colors cursor-pointer last:border-b-0 ${
+									selected.has(asset.id) ? "bg-blue-50/50" : "hover:bg-slate-50/60"
+								}`}
+							>
+								<div className="flex items-center justify-center">
+									<input
+										type="checkbox"
+										checked={selected.has(asset.id)}
+										onChange={() => toggleSelect(asset.id)}
+										onClick={(e) => e.stopPropagation()}
+										className="h-3.5 w-3.5 rounded border-slate-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+									/>
+								</div>
+								<div className="min-w-0">
+									<p className="text-sm text-slate-700 truncate">{asset.name}</p>
+									<p className="text-[11px] text-slate-400 truncate">{asset.identifier}</p>
+								</div>
+								<p className="hidden sm:block text-xs text-slate-500 truncate">{asset.category.name}</p>
+								<div className="hidden sm:block">
+									<span className={`inline-block rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusBadge(asset.status.short_name)}`}>
+										{asset.status.name}
+									</span>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Selection info */}
+			{selected.size > 0 && targetStatus && (
+				<div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3">
+					<p className="text-sm text-blue-700">
+						<span className="font-semibold">{selected.size}</span> asset{selected.size !== 1 ? "s" : ""} will be set to{" "}
+						<span className="font-semibold">{statusLabel(targetStatus as number)}</span>
+					</p>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default BulkAssetTool;

--- a/components/pages/team/tools/BulkVideoTool.tsx
+++ b/components/pages/team/tools/BulkVideoTool.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useState } from "react";
+import { reqGetVideos } from "../../../../services/api/video.service";
+import { reqUpdateVideo } from "../../../../services/api/video.service";
+import { Video } from "../../../../types";
+import { VideoStatuses } from "../../../../models/videoStatus.model";
+import Spinner from "../../../general/Spinner";
+import toast from "react-hot-toast";
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+const BulkVideoTool = () => {
+	const [videos, setVideos] = useState<Video[] | null>(null);
+	const [selected, setSelected] = useState<Set<number>>(new Set());
+	const [targetStatus, setTargetStatus] = useState<number | "">("");
+	const [applying, setApplying] = useState(false);
+	const [filterStatus, setFilterStatus] = useState<number | "">("");
+	const [search, setSearch] = useState("");
+
+	const fetchVideos = useCallback(async () => {
+		setVideos(null);
+		setSelected(new Set());
+		const params: any = { limit: 500, offset: 0 };
+		if (filterStatus) params.status = String(filterStatus);
+		if (search) params.search = search;
+		const res = await reqGetVideos(params);
+		if (res.success) {
+			setVideos(res.data);
+		} else {
+			setVideos([]);
+			toast.error("Failed to load videos");
+		}
+	}, [filterStatus, search]);
+
+	useEffect(() => {
+		fetchVideos();
+	}, [fetchVideos]);
+
+	const toggleSelect = (id: number) => {
+		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	};
+
+	const toggleAll = () => {
+		if (!videos) return;
+		if (selected.size === videos.length) {
+			setSelected(new Set());
+		} else {
+			setSelected(new Set(videos.map((v) => v.id)));
+		}
+	};
+
+	const applyBulkStatus = async () => {
+		if (!targetStatus || selected.size === 0) return;
+		setApplying(true);
+		let succeeded = 0;
+		let failed = 0;
+
+		const ids = Array.from(selected);
+		// Process in batches of 5 to avoid overwhelming the API
+		for (let i = 0; i < ids.length; i += 5) {
+			const batch = ids.slice(i, i + 5);
+			const results = await Promise.all(
+				batch.map((id) => reqUpdateVideo(id, { status: targetStatus as number }))
+			);
+			results.forEach((r) => {
+				if (r.success) succeeded++;
+				else failed++;
+			});
+		}
+
+		setApplying(false);
+		if (failed === 0) {
+			toast.success(`Updated ${succeeded} video${succeeded !== 1 ? "s" : ""}`, { position: "top-center" });
+		} else {
+			toast.error(`${succeeded} succeeded, ${failed} failed`, { position: "top-center" });
+		}
+		setSelected(new Set());
+		setTargetStatus("");
+		fetchVideos();
+	};
+
+	const statusLabel = (id: number) => VideoStatuses.find((s) => s.id === id)?.name ?? "Unknown";
+
+	const statusBadge = (statusName: string) => {
+		const map: Record<string, string> = {
+			public: "bg-emerald-50 text-emerald-700 border-emerald-200",
+			draft: "bg-amber-50 text-amber-700 border-amber-200",
+			unlisted: "bg-blue-50 text-blue-700 border-blue-200",
+			archived: "bg-red-50 text-red-600 border-red-200",
+		};
+		return map[statusName.toLowerCase()] ?? "bg-slate-50 text-slate-600 border-slate-200";
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			{/* Controls */}
+			<div className="flex flex-col sm:flex-row gap-3 items-start sm:items-end">
+				{/* Filter by status */}
+				<div className="flex flex-col gap-1.5">
+					<label className="text-xs font-semibold text-slate-600">Filter by Status</label>
+					<select
+						value={filterStatus}
+						onChange={(e) => setFilterStatus(e.target.value ? Number(e.target.value) : "")}
+						className="h-9 rounded-lg border border-slate-200 bg-white px-3 pr-7 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400 appearance-none cursor-pointer"
+					>
+						<option value="">All statuses</option>
+						{VideoStatuses.map((s) => (
+							<option key={s.id} value={s.id}>{s.name}</option>
+						))}
+					</select>
+				</div>
+
+				{/* Search */}
+				<div className="flex flex-col gap-1.5 flex-1 min-w-0">
+					<label className="text-xs font-semibold text-slate-600">Search</label>
+					<input
+						type="text"
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						placeholder="Search videos..."
+						className="h-9 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-slate-700 shadow-sm placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+					/>
+				</div>
+
+				{/* Divider */}
+				<div className="hidden sm:block h-9 w-px bg-slate-200" />
+
+				{/* Target status */}
+				<div className="flex flex-col gap-1.5">
+					<label className="text-xs font-semibold text-slate-600">Set Status To</label>
+					<select
+						value={targetStatus}
+						onChange={(e) => setTargetStatus(e.target.value ? Number(e.target.value) : "")}
+						className="h-9 rounded-lg border border-slate-200 bg-white px-3 pr-7 text-sm text-slate-700 shadow-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400 appearance-none cursor-pointer"
+					>
+						<option value="">Select status...</option>
+						{VideoStatuses.map((s) => (
+							<option key={s.id} value={s.id}>{s.name}</option>
+						))}
+					</select>
+				</div>
+
+				{/* Apply button */}
+				<button
+					onClick={applyBulkStatus}
+					disabled={!targetStatus || selected.size === 0 || applying}
+					className="h-9 rounded-lg bg-blue-600 px-4 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+				>
+					{applying ? (
+						<>
+							<svg className="h-3.5 w-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+								<circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+								<path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+							</svg>
+							Applying...
+						</>
+					) : (
+						<>Apply to {selected.size} selected</>
+					)}
+				</button>
+			</div>
+
+			{/* Table */}
+			{videos === null ? (
+				<div className="flex items-center justify-center py-12">
+					<Spinner />
+				</div>
+			) : videos.length === 0 ? (
+				<div className="flex flex-col items-center justify-center py-12 text-center">
+					<p className="text-sm font-medium text-slate-700">No videos found</p>
+					<p className="mt-1 text-xs text-slate-400">Try adjusting your filters</p>
+				</div>
+			) : (
+				<div className="overflow-hidden rounded-xl border border-slate-100">
+					{/* Header */}
+					<div className="grid grid-cols-[40px_1fr_120px_100px] items-center gap-x-3 border-b border-slate-100 bg-slate-50/80 px-4 py-2 text-xs font-semibold text-slate-500">
+						<div className="flex items-center justify-center">
+							<input
+								type="checkbox"
+								checked={videos.length > 0 && selected.size === videos.length}
+								onChange={toggleAll}
+								className="h-3.5 w-3.5 rounded border-slate-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+							/>
+						</div>
+						<p>Title</p>
+						<p className="hidden sm:block">Status</p>
+						<p className="hidden sm:block text-right">Views</p>
+					</div>
+
+					{/* Rows */}
+					<div className="max-h-[400px] overflow-y-auto">
+						{videos.map((video) => (
+							<div
+								key={video.id}
+								onClick={() => toggleSelect(video.id)}
+								className={`grid grid-cols-[40px_1fr_120px_100px] items-center gap-x-3 border-b border-slate-50 px-4 py-2.5 transition-colors cursor-pointer last:border-b-0 ${
+									selected.has(video.id) ? "bg-blue-50/50" : "hover:bg-slate-50/60"
+								}`}
+							>
+								<div className="flex items-center justify-center">
+									<input
+										type="checkbox"
+										checked={selected.has(video.id)}
+										onChange={() => toggleSelect(video.id)}
+										onClick={(e) => e.stopPropagation()}
+										className="h-3.5 w-3.5 rounded border-slate-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
+									/>
+								</div>
+								<p className="text-sm text-slate-700 truncate">{video.title}</p>
+								<div className="hidden sm:block">
+									<span className={`inline-block rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusBadge(video.status.name)}`}>
+										{video.status.name}
+									</span>
+								</div>
+								<p className="hidden sm:block text-xs text-slate-500 text-right tabular-nums">
+									{video.views.toLocaleString()}
+								</p>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Selection info */}
+			{selected.size > 0 && targetStatus && (
+				<div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3">
+					<p className="text-sm text-blue-700">
+						<span className="font-semibold">{selected.size}</span> video{selected.size !== 1 ? "s" : ""} will be set to{" "}
+						<span className="font-semibold">{statusLabel(targetStatus as number)}</span>
+					</p>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default BulkVideoTool;

--- a/components/pages/team/tools/DataExportTool.tsx
+++ b/components/pages/team/tools/DataExportTool.tsx
@@ -1,0 +1,233 @@
+import { useState } from "react";
+import { reqGetVideos } from "../../../../services/api/video.service";
+import { reqGetAssets } from "../../../../services/api/asset.service";
+import { reqGetLinks } from "../../../../services/api/link.service";
+import { reqGetPlaylists } from "../../../../services/api/playlist.service";
+import { reqGetCheckouts } from "../../../../services/api/checkout.service";
+import { reqGetUsers, reqGetMobileUsers } from "../../../../services/api/user.service";
+import toast from "react-hot-toast";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type ExportType = "videos" | "assets" | "links" | "playlists" | "checkouts" | "users" | "mobile_users";
+
+interface ExportOption {
+	id: ExportType;
+	label: string;
+	description: string;
+}
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const EXPORT_OPTIONS: ExportOption[] = [
+	{ id: "videos", label: "Videos", description: "All videos with title, status, views, downloads, creator" },
+	{ id: "assets", label: "Assets", description: "All assets with name, category, status, metadata" },
+	{ id: "links", label: "Links", description: "All links with route, destination, clicks, status" },
+	{ id: "playlists", label: "Playlists", description: "All playlists with name, route, status, video count" },
+	{ id: "checkouts", label: "Checkouts", description: "All checkouts with asset, user, status, times" },
+	{ id: "users", label: "Team Users", description: "All team users with name, email, role, last active" },
+	{ id: "mobile_users", label: "Mobile Users", description: "All mobile users with name, email, NFC ID, status" },
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const escapeCsvField = (val: string): string => {
+	if (val.includes(",") || val.includes('"') || val.includes("\n")) {
+		return `"${val.replace(/"/g, '""')}"`;
+	}
+	return val;
+};
+
+const toCsv = (headers: string[], rows: string[][]): string => {
+	const headerLine = headers.map(escapeCsvField).join(",");
+	const dataLines = rows.map((row) => row.map(escapeCsvField).join(","));
+	return [headerLine, ...dataLines].join("\n");
+};
+
+const downloadCsv = (csv: string, filename: string) => {
+	const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement("a");
+	a.href = url;
+	a.download = `${filename}-${new Date().toISOString().slice(0, 10)}.csv`;
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+	URL.revokeObjectURL(url);
+};
+
+// ─── Fetchers ────────────────────────────────────────────────────────────────
+
+const fetchAndExport: Record<ExportType, () => Promise<void>> = {
+	videos: async () => {
+		const res = await reqGetVideos({ limit: 10000, offset: 0 });
+		if (!res.success) throw new Error("Failed to fetch videos");
+		const headers = ["ID", "Title", "Description", "Status", "Views", "Downloads", "Creator", "URL", "Created"];
+		const rows = res.data.map((v) => [
+			String(v.id),
+			v.title,
+			v.description,
+			v.status.name,
+			String(v.views),
+			String(v.downloads),
+			v.creator?.name ?? "",
+			v.url,
+			v.inserted_at,
+		]);
+		downloadCsv(toCsv(headers, rows), "hillview-videos");
+	},
+	assets: async () => {
+		const res = await reqGetAssets({ limit: 10000, offset: 0, sort: "DESC" });
+		if (!res.success) throw new Error("Failed to fetch assets");
+		const headers = ["ID", "Name", "Identifier", "Category", "Status", "Serial Number", "Manufacturer", "Model", "Notes", "Created"];
+		const rows = res.data.map((a) => [
+			String(a.id),
+			a.name,
+			a.identifier,
+			a.category.name,
+			a.status.name,
+			a.metadata?.serial_number ?? "",
+			a.metadata?.manufacturer ?? "",
+			a.metadata?.model ?? "",
+			a.metadata?.notes ?? "",
+			a.inserted_at,
+		]);
+		downloadCsv(toCsv(headers, rows), "hillview-assets");
+	},
+	links: async () => {
+		const [activeRes, archivedRes] = await Promise.all([
+			reqGetLinks({ limit: 10000, offset: 0, active: true }),
+			reqGetLinks({ limit: 10000, offset: 0, active: false }),
+		]);
+		const active = activeRes.success ? activeRes.data : [];
+		const archived = archivedRes.success ? archivedRes.data : [];
+		const allLinks = [...active, ...archived];
+		if (allLinks.length === 0) throw new Error("No links found");
+		const headers = ["ID", "Route", "Destination", "Active", "Clicks", "Creator", "Created"];
+		const rows = allLinks.map((l) => [
+			String(l.id),
+			l.route,
+			l.destination,
+			l.active ? "Yes" : "No",
+			String(l.clicks),
+			l.creator.name,
+			l.inserted_at,
+		]);
+		downloadCsv(toCsv(headers, rows), "hillview-links");
+	},
+	playlists: async () => {
+		const res = await reqGetPlaylists({ limit: 10000, offset: 0 });
+		if (!res.success) throw new Error("Failed to fetch playlists");
+		const headers = ["ID", "Name", "Route", "Description", "Status", "Videos", "Created"];
+		const rows = res.data.map((p) => [
+			String(p.id),
+			p.name,
+			p.route,
+			p.description,
+			p.status.name,
+			String(p.videos?.length ?? 0),
+			p.inserted_at,
+		]);
+		downloadCsv(toCsv(headers, rows), "hillview-playlists");
+	},
+	checkouts: async () => {
+		const res = await reqGetCheckouts({ limit: 10000, offset: 0 });
+		if (!res.success) throw new Error("Failed to fetch checkouts");
+		const headers = ["ID", "Asset", "Asset ID", "User", "Status", "Notes", "Offsite", "Time Out", "Time In", "Expected In"];
+		const rows = res.data.map((c) => [
+			String(c.id),
+			c.asset?.name ?? "",
+			String(c.asset_id),
+			c.user?.name ?? "",
+			c.checkout_status.name,
+			c.checkout_notes ?? "",
+			c.offsite ? "Yes" : "No",
+			c.time_out ?? "",
+			c.time_in ?? "",
+			c.expected_in ?? "",
+		]);
+		downloadCsv(toCsv(headers, rows), "hillview-checkouts");
+	},
+	users: async () => {
+		const res = await reqGetUsers({ limit: 10000, offset: 0 });
+		if (!res.success) throw new Error("Failed to fetch users");
+		const headers = ["ID", "Name", "Username", "Email", "Role", "Last Active", "Created"];
+		const rows = res.data.map((u) => [
+			String(u.id),
+			u.name,
+			u.username,
+			u.email,
+			u.authentication.name,
+			u.last_active ?? "",
+			u.inserted_at,
+		]);
+		downloadCsv(toCsv(headers, rows), "hillview-users");
+	},
+	mobile_users: async () => {
+		const res = await reqGetMobileUsers({ limit: 10000, offset: 0 });
+		if (!res.success) throw new Error("Failed to fetch mobile users");
+		const headers = ["ID", "Name", "Email", "NFC Identifier", "Status", "Created"];
+		const rows = res.data.map((u) => [
+			String(u.id),
+			u.name,
+			u.email,
+			u.nfc_identifier,
+			u.status.name,
+			u.inserted_at,
+		]);
+		downloadCsv(toCsv(headers, rows), "hillview-mobile-users");
+	},
+};
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+const DataExportTool = () => {
+	const [exporting, setExporting] = useState<ExportType | null>(null);
+
+	const handleExport = async (type: ExportType) => {
+		setExporting(type);
+		try {
+			await fetchAndExport[type]();
+			toast.success("Export downloaded", { position: "top-center" });
+		} catch (err: any) {
+			toast.error(err.message || "Export failed", { position: "top-center" });
+		} finally {
+			setExporting(null);
+		}
+	};
+
+	return (
+		<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+			{EXPORT_OPTIONS.map((opt) => {
+				const isExporting = exporting === opt.id;
+				return (
+					<button
+						key={opt.id}
+						onClick={() => handleExport(opt.id)}
+						disabled={!!exporting}
+						className="flex items-start gap-3 rounded-xl border border-slate-100 bg-white p-4 text-left transition-colors hover:bg-slate-50 disabled:opacity-50 disabled:cursor-not-allowed"
+					>
+						<div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+							{isExporting ? (
+								<svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+									<circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+									<path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+								</svg>
+							) : (
+								<svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+									<path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+								</svg>
+							)}
+						</div>
+						<div className="min-w-0">
+							<p className="text-sm font-semibold text-slate-700">{opt.label}</p>
+							<p className="mt-0.5 text-xs text-slate-400 leading-relaxed">{opt.description}</p>
+						</div>
+					</button>
+				);
+			})}
+		</div>
+	);
+};
+
+export default DataExportTool;

--- a/components/pages/team/tools/PlatformOverview.tsx
+++ b/components/pages/team/tools/PlatformOverview.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from "react";
+import { reqGetVideos } from "../../../../services/api/video.service";
+import { reqGetAssets } from "../../../../services/api/asset.service";
+import { reqGetLinks } from "../../../../services/api/link.service";
+import { reqGetPlaylists } from "../../../../services/api/playlist.service";
+import { reqGetCheckouts } from "../../../../services/api/checkout.service";
+import { reqGetUsers, reqGetMobileUsers } from "../../../../services/api/user.service";
+import Spinner from "../../../general/Spinner";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface StatCard {
+	label: string;
+	value: number | null;
+	breakdown?: { label: string; value: number; color: string }[];
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+const PlatformOverview = () => {
+	const [stats, setStats] = useState<StatCard[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const fetchStats = async () => {
+			setLoading(true);
+
+			const [
+				videosRes,
+				assetsRes,
+				linksActiveRes,
+				linksArchivedRes,
+				playlistsRes,
+				checkoutsRes,
+				usersRes,
+				mobileUsersRes,
+			] = await Promise.all([
+				reqGetVideos({ limit: 1000, offset: 0 }),
+				reqGetAssets({ limit: 1000, offset: 0, sort: "DESC" }),
+				reqGetLinks({ limit: 1000, offset: 0, active: true }),
+				reqGetLinks({ limit: 1000, offset: 0, active: false }),
+				reqGetPlaylists({ limit: 1000, offset: 0 }),
+				reqGetCheckouts({ limit: 1000, offset: 0 }),
+				reqGetUsers({ limit: 1000, offset: 0 }),
+				reqGetMobileUsers({ limit: 1000, offset: 0 }),
+			]);
+
+			const videos = videosRes.success ? videosRes.data : [];
+			const assets = assetsRes.success ? assetsRes.data : [];
+			const activeLinks = linksActiveRes.success ? linksActiveRes.data : [];
+			const archivedLinks = linksArchivedRes.success ? linksArchivedRes.data : [];
+			const playlists = playlistsRes.success ? playlistsRes.data : [];
+			const checkouts = checkoutsRes.success ? checkoutsRes.data : [];
+			const users = usersRes.success ? usersRes.data : [];
+			const mobileUsers = mobileUsersRes.success ? mobileUsersRes.data : [];
+
+			// Video breakdown by status
+			const videoPublic = videos.filter((v) => v.status.short_name === "public").length;
+			const videoDraft = videos.filter((v) => v.status.short_name === "draft").length;
+			const videoUnlisted = videos.filter((v) => v.status.short_name === "unlisted").length;
+			const videoArchived = videos.filter((v) => v.status.short_name === "archived").length;
+
+			// Asset breakdown by status
+			const assetInService = assets.filter((a) => a.status.short_name === "in_service").length;
+			const assetReady = assets.filter((a) => a.status.short_name === "ready_for_sale").length;
+			const assetRepair = assets.filter((a) => a.status.short_name === "pending_repair").length;
+			const assetBroken = assets.filter((a) => a.status.short_name === "broken").length;
+			const assetLost = assets.filter((a) => a.status.short_name === "lost").length;
+
+			// User breakdown by role
+			const adminUsers = users.filter((u) => u.authentication.short_name === "admin").length;
+			const studentUsers = users.filter((u) => u.authentication.short_name === "student").length;
+			const pendingUsers = users.filter((u) => u.authentication.short_name === "unauthorized").length;
+
+			// Checkout breakdown
+			const activeCheckouts = checkouts.filter((c) => c.checkout_status.short_name === "checked_out" || !c.time_in).length;
+			const completedCheckouts = checkouts.filter((c) => c.checkout_status.short_name === "checked_in" || !!c.time_in).length;
+
+			setStats([
+				{
+					label: "Videos",
+					value: videos.length,
+					breakdown: [
+						{ label: "Public", value: videoPublic, color: "bg-emerald-500" },
+						{ label: "Draft", value: videoDraft, color: "bg-amber-500" },
+						{ label: "Unlisted", value: videoUnlisted, color: "bg-blue-500" },
+						{ label: "Archived", value: videoArchived, color: "bg-red-400" },
+					],
+				},
+				{
+					label: "Assets",
+					value: assets.length,
+					breakdown: [
+						{ label: "In Service", value: assetInService, color: "bg-emerald-500" },
+						{ label: "Ready", value: assetReady, color: "bg-blue-500" },
+						{ label: "Repair", value: assetRepair, color: "bg-amber-500" },
+						{ label: "Broken", value: assetBroken, color: "bg-red-400" },
+						{ label: "Lost", value: assetLost, color: "bg-slate-400" },
+					],
+				},
+				{
+					label: "Links",
+					value: activeLinks.length + archivedLinks.length,
+					breakdown: [
+						{ label: "Active", value: activeLinks.length, color: "bg-emerald-500" },
+						{ label: "Archived", value: archivedLinks.length, color: "bg-slate-400" },
+					],
+				},
+				{
+					label: "Playlists",
+					value: playlists.length,
+				},
+				{
+					label: "Team Users",
+					value: users.length,
+					breakdown: [
+						{ label: "Admin", value: adminUsers, color: "bg-blue-500" },
+						{ label: "Student", value: studentUsers, color: "bg-emerald-500" },
+						{ label: "Pending", value: pendingUsers, color: "bg-amber-500" },
+					],
+				},
+				{
+					label: "Mobile Users",
+					value: mobileUsers.length,
+				},
+				{
+					label: "Checkouts",
+					value: checkouts.length,
+					breakdown: [
+						{ label: "Active", value: activeCheckouts, color: "bg-amber-500" },
+						{ label: "Returned", value: completedCheckouts, color: "bg-emerald-500" },
+					],
+				},
+			]);
+
+			setLoading(false);
+		};
+
+		fetchStats();
+	}, []);
+
+	if (loading) {
+		return (
+			<div className="flex items-center justify-center py-16">
+				<Spinner />
+			</div>
+		);
+	}
+
+	return (
+		<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+			{stats.map((stat) => (
+				<div
+					key={stat.label}
+					className="rounded-xl border border-slate-100 bg-white p-5 shadow-sm"
+				>
+					<p className="text-xs font-semibold uppercase tracking-wider text-slate-400 mb-1">
+						{stat.label}
+					</p>
+					<p className="text-3xl font-bold text-slate-800 tabular-nums">
+						{stat.value ?? "—"}
+					</p>
+
+					{stat.breakdown && stat.breakdown.length > 0 && (
+						<div className="mt-3 pt-3 border-t border-slate-50">
+							{/* Bar */}
+							{stat.value && stat.value > 0 && (
+								<div className="flex h-1.5 w-full overflow-hidden rounded-full bg-slate-100 mb-2.5">
+									{stat.breakdown.map((b) =>
+										b.value > 0 ? (
+											<div
+												key={b.label}
+												className={`${b.color} transition-all duration-300`}
+												style={{ width: `${(b.value / stat.value!) * 100}%` }}
+											/>
+										) : null
+									)}
+								</div>
+							)}
+							{/* Legend */}
+							<div className="flex flex-wrap gap-x-3 gap-y-1">
+								{stat.breakdown.map((b) => (
+									<div key={b.label} className="flex items-center gap-1.5">
+										<span className={`inline-block h-2 w-2 rounded-full ${b.color}`} />
+										<span className="text-[11px] text-slate-500">
+											{b.label}{" "}
+											<span className="font-medium text-slate-700">{b.value}</span>
+										</span>
+									</div>
+								))}
+							</div>
+						</div>
+					)}
+				</div>
+			))}
+		</div>
+	);
+};
+
+export default PlatformOverview;

--- a/components/pages/team/tools/QRCodeTool.tsx
+++ b/components/pages/team/tools/QRCodeTool.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import QRCodeDesigner from "../link/QRCodeDesigner";
+
+const QRCodeTool = () => {
+	const [url, setUrl] = useState("");
+
+	return (
+		<div className="flex flex-col lg:flex-row gap-6">
+			{/* URL input */}
+			<div className="flex-1">
+				<label className="block text-xs font-semibold text-slate-600 mb-2">
+					Enter URL
+				</label>
+				<input
+					type="url"
+					value={url}
+					onChange={(e) => setUrl(e.target.value)}
+					placeholder="https://hillview.tv/..."
+					className="w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-700 shadow-sm placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+				/>
+				<p className="mt-2 text-xs text-slate-400">
+					Enter any URL to generate a customizable QR code. Use the controls below to style it.
+				</p>
+			</div>
+
+			{/* QR Code Designer */}
+			<div className="w-full lg:w-[340px] flex-shrink-0">
+				<QRCodeDesigner url={url || "https://hillview.tv"} />
+			</div>
+		</div>
+	);
+};
+
+export default QRCodeTool;

--- a/pages/team/r/tools.tsx
+++ b/pages/team/r/tools.tsx
@@ -1,0 +1,185 @@
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { GetStaticProps } from "next";
+import TeamContainer from "../../../components/pages/team/TeamContainer";
+import TeamHeader from "../../../components/pages/team/TeamHeader";
+import PlatformOverview from "../../../components/pages/team/tools/PlatformOverview";
+import QRCodeTool from "../../../components/pages/team/tools/QRCodeTool";
+import DataExportTool from "../../../components/pages/team/tools/DataExportTool";
+import BulkVideoTool from "../../../components/pages/team/tools/BulkVideoTool";
+import BulkAssetTool from "../../../components/pages/team/tools/BulkAssetTool";
+
+// ─── Tool definitions ───────────────────────────────────────────────────────
+
+type ToolId = "overview" | "qr" | "export" | "bulk-video" | "bulk-asset";
+
+interface ToolDef {
+	id: ToolId;
+	label: string;
+	description: string;
+	icon: React.ReactNode;
+}
+
+const TOOLS: ToolDef[] = [
+	{
+		id: "overview",
+		label: "Platform Overview",
+		description: "Live stats across all resources",
+		icon: (
+			<svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+			</svg>
+		),
+	},
+	{
+		id: "qr",
+		label: "QR Code Generator",
+		description: "Create styled QR codes for any URL",
+		icon: (
+			<svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 013.75 9.375v-4.5zM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 01-1.125-1.125v-4.5zM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0113.5 9.375v-4.5z" />
+				<path strokeLinecap="round" strokeLinejoin="round" d="M6.75 6.75h.75v.75h-.75v-.75zM6.75 16.5h.75v.75h-.75v-.75zM16.5 6.75h.75v.75h-.75v-.75zM13.5 13.5h.75v.75h-.75v-.75zM13.5 19.5h.75v.75h-.75v-.75zM19.5 13.5h.75v.75h-.75v-.75zM19.5 19.5h.75v.75h-.75v-.75zM16.5 16.5h.75v.75h-.75v-.75z" />
+			</svg>
+		),
+	},
+	{
+		id: "export",
+		label: "Data Export",
+		description: "Download platform data as CSV",
+		icon: (
+			<svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+			</svg>
+		),
+	},
+	{
+		id: "bulk-video",
+		label: "Bulk Video Status",
+		description: "Batch update video statuses",
+		icon: (
+			<svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h1.5C5.496 19.5 6 18.996 6 18.375m-2.625 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-1.5A1.125 1.125 0 0118 18.375M20.625 4.5H3.375m17.25 0c.621 0 1.125.504 1.125 1.125M20.625 4.5h-1.5C18.504 4.5 18 5.004 18 5.625m3.75 0v1.5c0 .621-.504 1.125-1.125 1.125M3.375 4.5c-.621 0-1.125.504-1.125 1.125M3.375 4.5h1.5C5.496 4.5 6 5.004 6 5.625m-3.75 0v1.5c0 .621.504 1.125 1.125 1.125m0 0h1.5m-1.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m1.5-3.75C5.496 8.25 6 7.746 6 7.125v-1.5M4.875 8.25C5.496 8.25 6 8.754 6 9.375v1.5m0-5.25v5.25m0-5.25C6 5.004 6.504 4.5 7.125 4.5h9.75c.621 0 1.125.504 1.125 1.125m1.125 2.625h1.5m-1.5 0A1.125 1.125 0 0118 7.125v-1.5m1.125 2.625c-.621 0-1.125.504-1.125 1.125v1.5m2.625-2.625c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125M18 5.625v5.25M7.125 12h9.75m-9.75 0A1.125 1.125 0 016 10.875M7.125 12C6.504 12 6 12.504 6 13.125m0-2.25C6 11.496 5.496 12 4.875 12M18 10.875c0 .621-.504 1.125-1.125 1.125M18 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m-12 5.25v-5.25m0 5.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125m-12 0v-1.5c0-.621-.504-1.125-1.125-1.125M18 18.375v-5.25m0 5.25v-1.5c0-.621.504-1.125 1.125-1.125M18 13.125v1.5c0 .621.504 1.125 1.125 1.125M18 13.125c0-.621.504-1.125 1.125-1.125M6 13.125v1.5c0 .621-.504 1.125-1.125 1.125M6 13.125C6 12.504 5.496 12 4.875 12m-1.5 0h1.5m-1.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M19.125 12h1.5m0 0c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h1.5m14.25 0h1.5" />
+			</svg>
+		),
+	},
+	{
+		id: "bulk-asset",
+		label: "Bulk Asset Status",
+		description: "Batch update asset statuses",
+		icon: (
+			<svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+				<path strokeLinecap="round" strokeLinejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z" />
+			</svg>
+		),
+	},
+];
+
+// ─── Tool content renderer ──────────────────────────────────────────────────
+
+const ToolContent = ({ toolId }: { toolId: ToolId }) => {
+	switch (toolId) {
+		case "overview":
+			return <PlatformOverview />;
+		case "qr":
+			return <QRCodeTool />;
+		case "export":
+			return <DataExportTool />;
+		case "bulk-video":
+			return <BulkVideoTool />;
+		case "bulk-asset":
+			return <BulkAssetTool />;
+	}
+};
+
+// ─── Page ────────────────────────────────────────────────────────────────────
+
+const ToolsPage = () => {
+	const router = useRouter();
+	const [activeTool, setActiveTool] = useState<ToolId | null>(null);
+
+	const activeDef = TOOLS.find((t) => t.id === activeTool);
+
+	return (
+		<TeamContainer pageTitle="Tools" router={router}>
+			<TeamHeader title="Admin Tools" />
+
+			{/* Tool cards */}
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3 pb-4">
+				{TOOLS.map((tool) => {
+					const isActive = activeTool === tool.id;
+					return (
+						<button
+							key={tool.id}
+							onClick={() => setActiveTool(isActive ? null : tool.id)}
+							className={`flex items-start gap-3 rounded-xl border p-4 text-left transition-all ${
+								isActive
+									? "border-blue-500 bg-blue-50 ring-1 ring-blue-500"
+									: "border-slate-100 bg-white hover:border-slate-200 hover:shadow-sm"
+							}`}
+						>
+							<div
+								className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg transition-colors ${
+									isActive
+										? "bg-blue-600 text-white"
+										: "bg-slate-100 text-slate-500"
+								}`}
+							>
+								{tool.icon}
+							</div>
+							<div className="min-w-0">
+								<p className={`text-sm font-semibold ${isActive ? "text-blue-700" : "text-slate-700"}`}>
+									{tool.label}
+								</p>
+								<p className={`mt-0.5 text-xs leading-relaxed ${isActive ? "text-blue-500" : "text-slate-400"}`}>
+									{tool.description}
+								</p>
+							</div>
+						</button>
+					);
+				})}
+			</div>
+
+			{/* Active tool content */}
+			{activeTool && activeDef && (
+				<div className="pb-8">
+					<div className="rounded-xl border border-slate-100 bg-white shadow-sm">
+						{/* Tool header */}
+						<div className="flex items-center justify-between border-b border-slate-100 px-5 py-3">
+							<div className="flex items-center gap-2.5">
+								<div className="flex h-7 w-7 items-center justify-center rounded-md bg-blue-600 text-white">
+									<div className="scale-[0.7]">{activeDef.icon}</div>
+								</div>
+								<h3 className="text-sm font-semibold text-slate-800">{activeDef.label}</h3>
+							</div>
+							<button
+								onClick={() => setActiveTool(null)}
+								className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600"
+							>
+								<svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+									<path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+								</svg>
+							</button>
+						</div>
+
+						{/* Tool body */}
+						<div className="p-5">
+							<ToolContent toolId={activeTool} />
+						</div>
+					</div>
+				</div>
+			)}
+		</TeamContainer>
+	);
+};
+
+export default ToolsPage;
+
+export const getStaticProps: GetStaticProps = () => {
+	return {
+		props: {
+			requireAuth: true,
+			requireAccountStatus: "admin",
+			title: "Hillview Team - Tools",
+		},
+	};
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2020",
     "moduleDetection": "force",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,12 +14,18 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds a new admin-only tools page at `/team/r/tools` with 5 fully functional tools
- Platform Overview with live resource stats, QR Code Generator, CSV Data Export, Bulk Video Status, and Bulk Asset Status
- Adds Tools nav item to the sidebar under the Manage section

## Test plan
- [ ] Navigate to `/team/r/tools` and verify all 5 tools render
- [ ] Test Platform Overview loads stats correctly
- [ ] Test QR Code Generator with various URLs
- [ ] Test Data Export downloads valid CSVs for each resource
- [ ] Test Bulk Video/Asset status changes apply correctly
- [ ] Verify Tools nav item appears for admin users only

🤖 Generated with [Claude Code](https://claude.com/claude-code)